### PR TITLE
Better null handling

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,9 @@ services:
 
   harper:
     image: harpersystems/harper:4.6.0-alpha.1
+    build:
+      context: ../harper
+      dockerfile: ../harper/utility/dev/Dockerfile
     container_name: 'gds-harper'
     user: root
     volumes:


### PR DESCRIPTION
This PR makes two changes to better handle JSON null values (which are now going to be much more common thanks to https://github.com/HarperDB/harperdb/pull/2597):

1. It uses pointer types in all Grafana fields to allow setting them to `nil` (Go equivalent of null) in the first place.
2. It counts any leading nils until we get a value we can determine the actual field type from, then it creates the field of that type and prepends the tracked number of nils to it 😅 