### PR TITLE
Release prep

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-        grafana_version: ${GRAFANA_VERSION:-11.6.1}
+        grafana_version: ${GRAFANA_VERSION:-12.0.0}
         development: ${DEVELOPMENT:-false}
     ports:
       - 3000:3000/tcp

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -10,9 +10,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"maps"
 	"reflect"
+	"slices"
 	"sort"
-	"strconv"
 	"time"
 )
 
@@ -140,98 +141,10 @@ type queryModel[Q Query] struct {
 	QueryAttrs Q      `json:"queryAttrs"`
 }
 
-func appendVal[T any](dest map[string]*data.Field, fieldName string, val T, fieldNils map[string]int) {
-	if dest[fieldName] == nil {
-		dest[fieldName] = data.NewField(fieldName, nil, []*T{})
-		if fieldNils[fieldName] > 0 {
-			for _ = range fieldNils[fieldName] {
-				dest[fieldName].Append(nil)
-			}
-		}
-	}
-	dest[fieldName].Append(&val)
-}
-
-// flattenMap recursively converts nested Harper query result data structures
-// into flat Grafana fields by appending prefixes to the field names
-// reflecting the key path to that data in the original structure.
-func flattenMap(source map[string]any, dest map[string]*data.Field, namePrefix string) {
-	// keep track of initial nils so we can prepend those once we get a value that allows us to determine the field type
-	fieldNils := make(map[string]int)
-
-	for k, value := range source {
-		fieldName := namePrefix + k
-
-		switch v := value.(type) {
-		case string:
-			appendVal(dest, fieldName, v, fieldNils)
-		case bool:
-			appendVal(dest, fieldName, v, fieldNils)
-		case float64:
-			appendVal(dest, fieldName, v, fieldNils)
-		case int64:
-			appendVal(dest, fieldName, v, fieldNils)
-		case time.Time:
-			appendVal(dest, fieldName, v, fieldNils)
-		case map[string]any:
-			// For some reason neither this nor the []map[string]any cases
-			// match when we seemingly have those types in the data. So I
-			// implemented a reflection-based approach to catch them in the
-			// default case below. - WSM 2025-01-09
-			log.DefaultLogger.Debug("map found in query results", "map", v)
-			//flattenMap(v, dest, fieldName+".")
-		case []map[string]any:
-			log.DefaultLogger.Debug("array of maps found in query results", "array", v)
-			// See comment in map[string]any case.
-			//for idx, val := range v {
-			//	flattenMap(val, dest, fieldName+"."+strconv.Itoa(idx)+".")
-			//}
-		case nil:
-			if dest[fieldName] == nil {
-				fieldNils[fieldName] += 1
-			} else {
-				dest[fieldName].Append(nil)
-			}
-		default:
-			// Sooo... this is a little hack-y and I don't love it. But when I
-			// print out the type of maps and/or slices of maps coming from
-			// query results, Go prints "map[]" which isn't a thing. It also
-			// prints that for the key and element types of the map, which is
-			// even weirder. So this reflection-based approach to catching and
-			// handling these is a workaround until I figure out what's going
-			// on there. - WSM 2025-01-09
-			val := reflect.ValueOf(value)
-			kind := val.Kind()
-			switch kind {
-			case reflect.Map:
-				keyType := val.Type().Key()
-				elemType := val.Type().Elem()
-				log.DefaultLogger.Debug("Map types", "key", keyType, "elem", elemType)
-				flattenMap(v.(map[string]any), dest, fieldName+".")
-			case reflect.Slice:
-				for i, x := range val.Interface().([]interface{}) {
-					xv := reflect.ValueOf(x)
-					log.DefaultLogger.Debug("xv", "Kind", xv.Kind())
-					if xv.Kind() == reflect.Map {
-						keyType := xv.Type().Key()
-						elemType := xv.Type().Elem()
-						log.DefaultLogger.Debug("Slice map types", "key", keyType, "elem", elemType)
-						flattenMap(x.(map[string]any), dest, fieldName+"."+strconv.Itoa(i)+".")
-					} else {
-						if dest[fieldName] == nil {
-							dest[fieldName] = data.NewField(fieldName, nil, v)
-						} else {
-							log.DefaultLogger.Warn("field name for slice already exists", "field", fieldName)
-						}
-					}
-				}
-			default:
-				log.DefaultLogger.Warn("Unknown type in query response", "field", fieldName, "type", reflect.TypeOf(v), "value", v)
-				val := reflect.ValueOf(value)
-				log.DefaultLogger.Debug("val", "Kind", val.Kind())
-			}
-		}
-	}
+type analyticsTable struct {
+	Headers    []string
+	FieldTypes []data.FieldType
+	Rows       [][]any
 }
 
 func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, query backend.DataQuery) (backend.DataResponse, error) {
@@ -246,12 +159,6 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 
 	log.DefaultLogger.Debug("Query", "operation", qo)
 
-	// create data frame response.
-	// For an overview on data frames and how grafana handles them:
-	// https://grafana.com/developers/plugin-tools/introduction/data-frames
-	frame := data.NewFrame("response")
-	frame.RefID = query.RefID
-
 	switch qo.Operation {
 	case "get_analytics":
 		var qm queryModel[GetAnalyticsQuery]
@@ -261,94 +168,113 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 		}
 		request := qm.QueryAttrs
 		log.DefaultLogger.Debug("Query", "request", request)
-		metric := request.Metric
-		getAttrs := request.Attributes
 
-		results, err := d.harperClient.GetAnalytics(metric, getAttrs, request.From, request.To)
+
+		req := harper.GetAnalyticsRequest{
+			Metric:        request.Metric,
+			GetAttributes: request.Attributes,
+			StartTime:     request.From,
+			EndTime:       request.To,
+		}
+
+		results, err := d.harperClient.GetAnalytics(req)
 		if err != nil {
 			return backend.DataResponse{}, fmt.Errorf("could not query Harper analytics: '%s': '%w'", query.JSON, err)
 		}
 
 		log.DefaultLogger.Debug("Get analytics query results", "results", results)
 
-		mappedFields := make(map[string]*data.Field)
+		// Collect the superset of all fields in the results.
+		// Grafana gets very cranky if any rows have a different set of fields (columns), so we have to make sure they
+		// all have all of them.
+		allFields := make(map[string]bool)
 		for _, result := range results {
-			log.DefaultLogger.Debug("get_analytics result fields", "count", len(result), "results", result)
-			flattenMap(result, mappedFields, "")
+			for k := range result {
+				allFields[k] = true
+			}
 		}
 
-		fields := make(data.Fields, 0, len(mappedFields))
-		// ensure stable sort order of fields; o/w Grafana changes their colors
-		// and positions in the legend on every refresh
-		keys := make([]string, 0, len(mappedFields))
-		for k := range mappedFields {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			fields = append(fields, mappedFields[k])
+		headers := slices.Collect(maps.Keys(allFields))
+		// Sort the header names so they don't get jumbled on every Grafana refresh
+		sort.Strings(headers)
+
+		grafanaAnalytics := analyticsTable{
+			Headers: headers,
 		}
 
-		frame.Fields = fields
-	case "search_by_conditions":
-		var qm queryModel[SearchByConditionsQuery]
-		err := json.Unmarshal(query.JSON, &qm)
-		if err != nil {
-			return backend.DataResponse{}, fmt.Errorf("could not unmarshal search_by_conditions query JSON: '%s': '%w'", query.JSON, err)
-		}
-		search := qm.QueryAttrs
+		grafanaAnalytics.FieldTypes = make([]data.FieldType, len(grafanaAnalytics.Headers))
 
-		conditions := make([]harper.SearchCondition, 0, len(search.Conditions))
-		for _, condition := range search.Conditions {
-			conditions = append(conditions, harper.SearchCondition{
-				Attribute: condition.SearchAttribute,
-				Type:      condition.SearchType,
-				Value:     condition.SearchValue.Val,
-				Operator:  condition.Operator,
-			})
-		}
-
-		log.DefaultLogger.Debug("Query", "conditions", conditions)
-
-		getAttrs := search.Attributes
-		if len(getAttrs) == 0 {
-			getAttrs = []string{"*"}
-		}
-
-		log.DefaultLogger.Debug("Query", "getAttrs", getAttrs)
-
-		opts := harper.SearchByConditionsOptions{Operator: search.Operator}
-
-		log.DefaultLogger.Debug("Query", "opts", opts)
-
-		log.DefaultLogger.Debug("Query", "database", search.Database, "table", search.Table)
-		results := make([]map[string]any, 0)
-		err = d.harperClient.SearchByConditions(search.Database, search.Table, &results, conditions, getAttrs, opts)
-		if err != nil {
-			return backend.DataResponse{}, fmt.Errorf("error querying Harper: %w", err)
-		}
-
-		log.DefaultLogger.Debug("Query", "results", results)
-
-		mappedFields := make(map[string]*data.Field)
 		for _, result := range results {
-			log.DefaultLogger.Debug("Result fields", "count", len(result), "results", result)
-			flattenMap(result, mappedFields, "")
+			row := make([]any, len(grafanaAnalytics.Headers))
+			for i, header := range grafanaAnalytics.Headers {
+				val, ok := result[header]
+				if !ok {
+					log.DefaultLogger.Debug("Header not found in result; assigning nil", "header", header)
+					row[i] = nil
+				} else {
+					log.DefaultLogger.Debug("Row", "header", header, "val", val, "type", reflect.TypeOf(val).String())
+					switch v := val.(type) {
+					case string:
+						if grafanaAnalytics.FieldTypes[i] == data.FieldTypeUnknown {
+							grafanaAnalytics.FieldTypes[i] = data.FieldTypeNullableString
+						}
+						row[i] = &v
+					case bool:
+						if grafanaAnalytics.FieldTypes[i] == data.FieldTypeUnknown {
+							grafanaAnalytics.FieldTypes[i] = data.FieldTypeNullableBool
+						}
+						row[i] = &v
+					case float64:
+						if grafanaAnalytics.FieldTypes[i] == data.FieldTypeUnknown {
+							grafanaAnalytics.FieldTypes[i] = data.FieldTypeNullableFloat64
+						}
+						row[i] = &v
+					case int64:
+						if grafanaAnalytics.FieldTypes[i] == data.FieldTypeUnknown {
+							grafanaAnalytics.FieldTypes[i] = data.FieldTypeNullableInt64
+						}
+						row[i] = &v
+					case time.Time:
+						if grafanaAnalytics.FieldTypes[i] == data.FieldTypeUnknown {
+							grafanaAnalytics.FieldTypes[i] = data.FieldTypeNullableTime
+						}
+						row[i] = &v
+					case nil:
+						log.DefaultLogger.Debug("Assigning nil", "header", header)
+						row[i] = nil
+					}
+				}
+			}
+			grafanaAnalytics.Rows = append(grafanaAnalytics.Rows, row)
 		}
 
-		fields := make(data.Fields, 0, len(mappedFields))
-		for _, field := range mappedFields {
-			fields = append(fields, field)
+		frame := data.NewFrameOfFieldTypes(
+			"response", 0,
+			grafanaAnalytics.FieldTypes...,
+		).SetMeta(
+			&data.FrameMeta{
+				Type:        data.FrameTypeTimeSeriesLong,
+				TypeVersion: data.FrameTypeVersion{0, 1},
+			},
+		).SetRefID(query.RefID)
+
+		err = frame.SetFieldNames(grafanaAnalytics.Headers...)
+		if err != nil {
+			return backend.DataResponse{}, fmt.Errorf("could not set field names on frame: '%s': '%w'", query.JSON, err)
 		}
 
-		frame.Fields = fields
+		for _, row := range grafanaAnalytics.Rows {
+			frame.AppendRow(row...)
+		}
+
+		st, _ := frame.StringTable(-1, -1)
+		log.DefaultLogger.Debug("Grafana analytics", "table", st)
+
+		response.Frames = append(response.Frames, frame)
+		return response, nil
 	default:
 		return backend.DataResponse{}, errors.New("unsupported Harper operation: " + qo.Operation)
 	}
-
-	response.Frames = append(response.Frames, frame)
-
-	return response, nil
 }
 
 // CheckHealth handles health checks sent from Grafana to the plugin.

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -261,13 +261,8 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 		}
 		request := qm.QueryAttrs
 		log.DefaultLogger.Debug("Query", "request", request)
-
 		metric := request.Metric
-
 		getAttrs := request.Attributes
-		if len(getAttrs) == 0 {
-			getAttrs = []string{"*"}
-		}
 
 		results, err := d.harperClient.GetAnalytics(metric, getAttrs, request.From, request.To)
 		if err != nil {

--- a/src/README.md
+++ b/src/README.md
@@ -1,8 +1,4 @@
-<!-- This README file is going to be the one displayed on the Grafana.com website for your plugin. Uncomment and replace the content here before publishing.
-
-Remove any remaining comments before publishing as these may be displayed on Grafana.com -->
-
-# Harperdb-Datasource
+# Harper Data Source
 
 <!-- To help maximize the impact of your README and improve usability for users, we propose the following loose structure:
 
@@ -28,23 +24,40 @@ to create dynamic badges that update automatically when you publish a new versio
 Full example: ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?logo=grafana&query=$.version&url=https://grafana.com/api/plugins/grafana-polystat-panel&label=Marketplace&prefix=v&color=F47A20)
 
 Consider other [badges](https://shields.io/badges) as you feel appropriate for your project.
+-->
 
 ## Overview / Introduction
-Provide one or more paragraphs as an introduction to your plugin to help users understand why they should use it.
 
+This plugin allows using any Harper 4.6+ cluster as a Grafana data source.
+
+It currently provides the following query forms:
+
+1. `get_analytics`: This Harper operation is useful for monitoring a Harper cluster in Grafana.
+1. `search_by_conditions`: This Harper search operation allows querying arbitrary data stored in Harper. [See here for more information.](https://docs.harperdb.io/docs/developers/operations-api/nosql-operations#search-by-conditions)
+
+<!--
 Consider including screenshots:
 - in [plugin.json](https://grafana.com/developers/plugin-tools/reference/plugin-json#info) include them as relative links.
 - in the README ensure they are absolute URLs.
 
 ## Requirements
 List any requirements or dependencies they may need to run the plugin.
+-->
 
 ## Getting Started
-Provide a quick start on how to configure and use the plugin.
 
+1. Install the plugin
+1. Add a data source using the plugin
+1. Configure the full URL to your Harper cluster's operations API (defaults to port 9925)
+1. Configure a Harper username and password that has permission to read the appropriate data and/or analytics
+
+<!--
 ## Documentation
 If your project has dedicated documentation available for users, provide links here. For help in following Grafana's style recommendations for technical documentation, refer to our [Writer's Toolkit](https://grafana.com/docs/writers-toolkit/).
+-->
 
 ## Contributing
-Do you want folks to contribute to the plugin or provide feedback through specific means? If so, tell them how!
--->
+
+This plugin is open source (see `LICENSE` file for details) and is [hosted on GitHub](https://github.com/HarperDB/grafana-datasource).
+
+Feel free to open issues or send us pull requests there.

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -380,7 +380,10 @@ function OpQueryEditor({ operation, datasource, query, onQueryAttrsChange }: OpQ
 }
 
 export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) {
-	const operations = ['get_analytics', 'search_by_conditions'];
+	// Supporting search_by_conditions again would require adapting it to the new backend data ingestion scheme
+	// get_analytics uses in datasource.go.
+	// const operations = ['get_analytics', 'search_by_conditions'];
+	const operations = ['get_analytics'];
 
 	const onQueryAttrsChange = (attrs: QueryAttrs) => {
 		onChange({ ...query, queryAttrs: attrs });
@@ -401,7 +404,8 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
 
 	return (
 		<Stack gap={2} direction="column">
-			<InlineField label="Operation">
+			{operations.length > 1 ? (
+				<InlineField label="Operation">
 				<Combobox
 					id="query-editor-operation"
 					options={operationOptions}
@@ -409,7 +413,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
 					value={operation}
 					width={40}
 				/>
-			</InlineField>
+			</InlineField>) : null}
 			{operation ? (
 				<OpQueryEditor
 					operation={operation}


### PR DESCRIPTION
9a4d822c043e01bd95b60f1c68a4ef511d5bbfb7 is the most important commit in here. It follows some examples and docs from here: https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data ...and moves all of the Grafana table format coercion logic into this plugin (where it belongs). I haven't seen a "fields have different lengths" error with this code.

Unfortunately `search_by_conditions` was a casualty of this change, as adapting it to this new approach seemed non-trivial. And `get_analytics` support is the priority for now.