### PR TITLE
Display string attrs as labels

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - grafana-harper
 
   harper:
-    image: harpersystems/harper:4.6.0-beta.1
+    image: harpersystems/harper:4.6.0
     build:
       context: ../harper
       dockerfile: ../harper/utility/dev/Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - grafana-harper
 
   harper:
-    image: harpersystems/harper:4.6.0-alpha.3
+    image: harpersystems/harper:4.6.0-beta.1
     build:
       context: ../harper
       dockerfile: ../harper/utility/dev/Dockerfile

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 toolchain go1.24.2
 
 require (
-	github.com/HarperDB/sdk-go v0.0.0-20250523153204-41b197c075a4
+	github.com/HarperDB/sdk-go v0.0.0-20250616174745-e54bbebd5ba0
 	github.com/grafana/grafana-plugin-sdk-go v0.278.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/HarperDB/sdk-go v0.0.0-20250523153204-41b197c075a4 h1:1J+9uW7i9iZtiloNWKhJdG0HdLDGaUWkLQEu3hZhCTE=
 github.com/HarperDB/sdk-go v0.0.0-20250523153204-41b197c075a4/go.mod h1:U3SVYLzsS1S4abhWeHQUde1Fyh6p3utrhe1R+jS24MQ=
+github.com/HarperDB/sdk-go v0.0.0-20250616174745-e54bbebd5ba0 h1:OuuJ8JjYlINZrryK3Pp5/R4d7Prrkg+OAp/j2ot8ZBA=
+github.com/HarperDB/sdk-go v0.0.0-20250616174745-e54bbebd5ba0/go.mod h1:U3SVYLzsS1S4abhWeHQUde1Fyh6p3utrhe1R+jS24MQ=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/apache/arrow-go/v18 v18.3.0 h1:Xq4A6dZj9Nu33sqZibzn012LNnewkTUlfKVUFD/RX/I=

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -13,7 +13,7 @@ import {
 } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
-import {
+import type {
 	AnalyticsQueryAttrs,
 	Condition,
 	HarperDataSourceOptions,

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -18,6 +18,7 @@ import {
 	Condition,
 	HarperDataSourceOptions,
 	HarperQuery,
+	MetricAttribute,
 	QueryAttrs,
 	SearchByConditionsQueryAttrs,
 } from '../types';
@@ -150,7 +151,14 @@ function ConditionForm({ datasource, queryAttrs, onQueryAttrsChange, loadAttribu
 	);
 }
 
-function ConditionsForm({ datasource, queryAttrs, onQueryAttrsChange, loadAttributes, onConditionAdd, onConditionRemove }: ConditionsFormProps) {
+function ConditionsForm({
+	datasource,
+	queryAttrs,
+	onQueryAttrsChange,
+	loadAttributes,
+	onConditionAdd,
+	onConditionRemove,
+}: ConditionsFormProps) {
 	const conditions = queryAttrs?.conditions;
 	return (
 		<div>
@@ -164,20 +172,18 @@ function ConditionsForm({ datasource, queryAttrs, onQueryAttrsChange, loadAttrib
 							loadAttributes={loadAttributes}
 							index={index}
 						/>
-						{conditions?.length > 1 ? (
-							<Button
-								className="btn btn-danger btn-small"
-								icon="trash-alt"
-								variant="destructive"
-								fill="outline"
-								size="sm"
-								style={{ margin: '5px' }}
-								onClick={(e) => {
-									onConditionRemove(index);
-									e.preventDefault();
-								}}
-							/>
-						) : null}
+						<Button
+							className="btn btn-danger btn-small"
+							icon="trash-alt"
+							variant="destructive"
+							fill="outline"
+							size="sm"
+							style={{ margin: '5px' }}
+							onClick={(e) => {
+								onConditionRemove(index);
+								e.preventDefault();
+							}}
+						/>
 					</div>
 				);
 			})}
@@ -194,7 +200,7 @@ function ConditionsForm({ datasource, queryAttrs, onQueryAttrsChange, loadAttrib
 								e.preventDefault();
 							}}
 						>
-							+
+							Add Condition
 						</Button>
 					</div>
 				</div>
@@ -234,16 +240,33 @@ function AnalyticsQueryEditor({ queryAttrs, onQueryAttrsChange, datasource }: An
 		[datasource]
 	);
 
+	const [attributes, setAttributes] = React.useState<MetricAttribute[]>([]);
+
 	const loadAttributes = React.useCallback(
 		async (input: string) => {
 			if (selectedMetric) {
 				// TODO: Filter attrs based on `input`
 				const desc = await datasource.describeMetric(selectedMetric);
-				return toComboboxOptions(desc.attributes);
+				setAttributes(desc.attributes);
+				return toComboboxOptions(desc.attributes.map((a) => a.name));
 			}
 			return [];
 		},
 		[datasource, selectedMetric]
+	);
+
+	const loadNumericAttributes = React.useCallback(
+		async (input: string) => {
+			if (selectedMetric) {
+				const desc = await datasource.describeMetric(selectedMetric);
+				const attrs = desc.attributes;
+				setAttributes(attrs);
+				const numericAttrs = attrs.filter((a) => a.type === 'number');
+				return toComboboxOptions(numericAttrs.map((a) => a.name));
+			}
+			return [];
+		},
+		[selectedMetric, datasource]
 	);
 
 	const nextConditionId = React.useRef((queryAttrs?.conditions?.length ?? 0) + 1);
@@ -259,14 +282,6 @@ function AnalyticsQueryEditor({ queryAttrs, onQueryAttrsChange, datasource }: An
 		conditions.splice(index, 1);
 		onQueryAttrsChange({ ...queryAttrs, conditions });
 	};
-
-	// ensure at least one blank condition form shows up
-	if (queryAttrs === undefined) {
-		onQueryAttrsChange({});
-	}
-	if (queryAttrs) {
-		queryAttrs.conditions ??= [newCondition(0)];
-	}
 
 	return (
 		<Stack gap={0} direction="column">
@@ -286,10 +301,19 @@ function AnalyticsQueryEditor({ queryAttrs, onQueryAttrsChange, datasource }: An
 					width="auto"
 					minWidth={25}
 					placeholder="*"
-					options={loadAttributes}
-					value={queryAttrs?.attributes ? toComboboxOptions(queryAttrs.attributes) : []}
+					options={loadNumericAttributes}
+					value={queryAttrs?.attributes ? toComboboxOptions(queryAttrs.attributes.filter((attr) => {
+						const numericAttrs = attributes.filter((a) => a.type === 'number');
+						return numericAttrs.map((na) => na.name).includes(attr);
+					})) : []}
 					onChange={(vs: Array<ComboboxOption<string>>) => {
-						onQueryAttrsChange({ ...queryAttrs, attributes: vs.map((v) => v.value) });
+						const labelAttrs = attributes.filter((attr) => attr.type !== 'number');
+						let selectedAttrs: string[] = [];
+						if (vs.length > 0) {
+							// ensure label attrs are always included
+							selectedAttrs = [...labelAttrs.map((a) => a.name), ...vs.map((v) => v.value)];
+						}
+						onQueryAttrsChange({ ...queryAttrs, attributes: selectedAttrs });
 					}}
 				/>
 			</InlineField>

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,11 @@ export interface HarperSecureJsonData {
 
 export type ListMetricsResponse = string[];
 
+export interface MetricAttribute {
+	name: string;
+	type: string;
+}
+
 export interface DescribeMetricResponse {
-	attributes: string[];
+	attributes: MetricAttribute[];
 }


### PR DESCRIPTION
This fixes the issue of graphs jumping all over the place because the values refer to different paths, methods, types, etc. By turning those string attributes into Grafana Labels, Grafana breaks them out into separate lines in the graph and you can then decide if you want to filter some out / only include one / etc. instead of seeing opaquely nonsensical visualizations.