### PR TITLE
CORE-2806: Early return empty response if no analytics returned

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -283,6 +283,12 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 			frame.AppendRow(row...)
 		}
 
+		if frame.Rows() == 0 {
+			// early return here so we don't get an error about being unable to convert to wide format
+			response.Frames = append(response.Frames, frame)
+			return response, nil
+		}
+
 		wideFrame, err := data.LongToWide(frame, &data.FillMissing{Mode: data.FillModeNull})
 		if err != nil {
 			return backend.DataResponse{}, fmt.Errorf("could not convert frame to wide format: '%w'", err)


### PR DESCRIPTION
...so we don't get an error about not being able to convert the frame to wide format. This happens when Harper has just started and hasn't aggregated any analytics yet.

Fixes CORE-2806