### PR TITLE
fix: React 19 / Grafana 13 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.2.1
+        with:
+          skip-grafana-react-19-preview-image: false
 
   playwright-tests:
     needs: [resolve-versions, build]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@emotion/css": "11.13.5",
 				"@grafana/data": "^12.3.3",
 				"@grafana/i18n": "^12.2.0",
-				"@grafana/plugin-ui": "^0.12.1",
+				"@grafana/plugin-ui": "^0.13.1",
 				"@grafana/runtime": "^12.3.3",
 				"@grafana/schema": "^12.2.0",
 				"@grafana/ui": "^12.3.3",
@@ -77,7 +77,6 @@
 			"version": "4.4.4",
 			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
 			"integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -1459,14 +1458,15 @@
 			}
 		},
 		"node_modules/@grafana/plugin-ui": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@grafana/plugin-ui/-/plugin-ui-0.12.1.tgz",
-			"integrity": "sha512-OIIySSay3iGBAhjK7tzTkpeBJIqNKR43FSS0yVveLWBRK5dxmYD911hz7oXrUr2qFvF0kVXZ/3M4BL7lgEQW9A==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/@grafana/plugin-ui/-/plugin-ui-0.13.1.tgz",
+			"integrity": "sha512-jdufyHl/Ok/XDSaMiZKZ4aCtosp7wsyCHoAQRw4mDFBAIgsvhC9nX9VR9kvNPCCPQo2qTiiBYdTxpB5ltFuKgA==",
 			"dependencies": {
 				"@emotion/css": "^11.11.2",
 				"@hello-pangea/dnd": "^17.0.0",
 				"@react-awesome-query-builder/ui": "^6.6.4",
 				"@types/prismjs": "^1.26.4",
+				"chance": "^1.1.7",
 				"lodash": "^4.17.21",
 				"prismjs": "^1.30.0",
 				"react-calendar": "^4.8.0",
@@ -1481,6 +1481,9 @@
 				"@grafana/e2e-selectors": ">=10.4.0",
 				"@grafana/runtime": ">=10.4.0",
 				"@grafana/ui": ">=10.4.0",
+				"@testing-library/jest-dom": ">=5.16.5",
+				"@testing-library/react": ">=15.0.2",
+				"@testing-library/user-event": ">=14.5.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"rxjs": "^7.8.1"
@@ -3957,7 +3960,6 @@
 			"version": "10.4.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
 			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -3978,7 +3980,6 @@
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
 			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@adobe/css-tools": "^4.4.0",
@@ -3998,14 +3999,12 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
 			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@testing-library/react": {
 			"version": "16.3.2",
 			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
 			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.12.5"
@@ -4027,6 +4026,20 @@
 				"@types/react-dom": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@testing-library/user-event": {
+			"version": "14.6.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+			"integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": ">=7.21.4"
 			}
 		},
 		"node_modules/@tsconfig/node10": {
@@ -4072,7 +4085,6 @@
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -5328,7 +5340,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5390,7 +5401,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"dequal": "^2.0.3"
@@ -5921,6 +5931,12 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/chance": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/chance/-/chance-1.1.13.tgz",
+			"integrity": "sha512-V6lQCljcLznE7tUYUM9EOAnnKXbctE6j/rdQkYOHIWbfGQbrzTsAXNW9CdU5XCo4ArXQCj/rb6HgxPlmGJcaUg==",
+			"license": "MIT"
+		},
 		"node_modules/char-regex": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -6288,7 +6304,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
 			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cssesc": {
@@ -6912,7 +6927,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -6978,7 +6992,6 @@
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -8922,7 +8935,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
 			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11073,7 +11085,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"bin": {
@@ -11297,7 +11308,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -12244,7 +12254,6 @@
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -12260,7 +12269,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -12274,7 +12282,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -13175,7 +13182,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
 			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"indent-string": "^4.0.0",
@@ -14416,7 +14422,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
 			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"min-indent": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"@emotion/css": "11.13.5",
 		"@grafana/data": "^12.3.3",
 		"@grafana/i18n": "^12.2.0",
-		"@grafana/plugin-ui": "^0.12.1",
+		"@grafana/plugin-ui": "^0.13.1",
 		"@grafana/runtime": "^12.3.3",
 		"@grafana/schema": "^12.2.0",
 		"@grafana/ui": "^12.3.3",


### PR DESCRIPTION
## Summary

- Bumps `@grafana/plugin-ui` from `0.12.1` to `0.13.1`, which resolves the bundled `react/jsx-runtime` issue detected by `@grafana/react-detect` (`jsxRuntimeImport` pattern)
- Pins the `e2e-version` CI action to `v1.2.1` and opts in to the React 19 Grafana preview image in the E2E matrix

You can find more information about this in [our blog post here](https://grafana.com/blog/react-19-is-coming-to-grafana-what-plugin-developers-need-to-know).

## Verification

`@grafana/react-detect` reports **0 issues** after the dependency bump:
```
"totalIssues": 0, "status": "no_action_required"
```

## Test plan

- [ ] CI E2E matrix runs against both React 18 and React 19 Grafana preview images
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)