### PR TITLE
Fix npm dependency CVEs flagged by plugin validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1044,9 +1044,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -1113,9 +1113,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -1293,30 +1293,31 @@
 			}
 		},
 		"node_modules/@grafana/data": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.3.3.tgz",
-			"integrity": "sha512-ZviEC8sKdMYof3ILxWUcgtySQRvfpCH6leLc0m4PY112kKg6ltTNkOM7PhZYNqnJO88AULDKYvTS/DNduakiCQ==",
+			"version": "12.4.4",
+			"resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.4.4.tgz",
+			"integrity": "sha512-B4ygpnBJMiP9/+1z0l7jhBeUaS62tz1uDo9fOmbk3pw5VMQspoG+6YPm/qz7b9J+QX+3Nby3qkXimnwHwSdzDg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@braintree/sanitize-url": "7.0.1",
-				"@grafana/i18n": "12.3.3",
-				"@grafana/schema": "12.3.3",
+				"@grafana/i18n": "12.4.4",
+				"@grafana/schema": "12.4.4",
 				"@leeoniya/ufuzzy": "1.0.19",
 				"@types/d3-interpolate": "^3.0.0",
 				"@types/string-hash": "1.1.3",
 				"@types/systemjs": "6.15.3",
 				"d3-interpolate": "3.0.1",
+				"d3-scale-chromatic": "3.1.0",
 				"date-fns": "4.1.0",
 				"dompurify": "3.3.0",
 				"eventemitter3": "5.0.1",
 				"fast_array_intersect": "1.1.0",
 				"history": "4.10.1",
-				"lodash": "^4.17.23",
+				"lodash": "^4.18.1",
 				"marked": "16.3.0",
-				"marked-mangle": "1.1.11",
+				"marked-mangle": "1.1.12",
 				"moment": "2.30.1",
 				"moment-timezone": "0.5.47",
-				"ol": "10.6.1",
+				"ol": "10.7.0",
 				"papaparse": "5.5.3",
 				"react-use": "17.6.0",
 				"rxjs": "7.8.2",
@@ -1324,7 +1325,8 @@
 				"tinycolor2": "1.6.0",
 				"tslib": "2.8.1",
 				"uplot": "1.6.32",
-				"xss": "^1.0.14"
+				"xss": "^1.0.14",
+				"zod": "^4.3.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -1332,9 +1334,9 @@
 			}
 		},
 		"node_modules/@grafana/e2e-selectors": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.3.3.tgz",
-			"integrity": "sha512-A83VWOosQXYTLzrsFk7e4KVAP050BKm0DALny9LKL5j8I8xjJJP7dDUbE85KGG+2Z4KN6AT0upo71Z+R6M3tCg==",
+			"version": "12.4.4",
+			"resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.4.tgz",
+			"integrity": "sha512-A3mnkM7kmCvK+g8/eImx3eOIT+zW1123FTIFOPZbBMzWWu8gQAzseov0W99wwT2Gv6mHiqFdezr0chVhY70a8w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"semver": "^7.7.0",
@@ -1374,30 +1376,30 @@
 			}
 		},
 		"node_modules/@grafana/faro-core": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.19.0.tgz",
-			"integrity": "sha512-Juo5G/aviSh3XqSGGr6D61noAC8sb+oCawBsv545ILEeOQdINyzRaoQdRpnXEY3DLS9LYtL0PYhvHZiP3rlscQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.7.1.tgz",
+			"integrity": "sha512-qJOp0sPBAEsmUxhs11nVdGx5Dk+VJ4CN/4s9ek99m33FfzybmjQ9nPXLHWhwEeNJNiEwQdDl4HsNUlXBGT5YEw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/otlp-transformer": "^0.202.0"
+				"@opentelemetry/otlp-transformer": "^0.218.0"
 			}
 		},
 		"node_modules/@grafana/faro-web-sdk": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.19.0.tgz",
-			"integrity": "sha512-3u74mV2uBWqoF6WBx71p0vtkaS1Z0QbGoZ8tuX5yiYnIybqnhKdGkApFUi7q5se0tMPIeJdMVoRFdLU8f9hfAw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.7.1.tgz",
+			"integrity": "sha512-ZK3MuE6FWBmiT5tTivcMovTVe8fG1tPm1ctc84blVoJkpQXlgODxOX7/fNmDBOjaHZ3EWdoGplZmjoXQ3g0mDw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grafana/faro-core": "^1.19.0",
-				"ua-parser-js": "^1.0.32",
-				"web-vitals": "^4.0.1"
+				"@grafana/faro-core": "^2.7.1",
+				"ua-parser-js": "1.0.41",
+				"web-vitals": "^5.1.0"
 			}
 		},
 		"node_modules/@grafana/i18n": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.3.3.tgz",
-			"integrity": "sha512-hVsGMzawxc8K7HoXbTDyBB0774XKl8iklk8f5KSGBlX4rswQaEC0BLgsqLrIQeoQ87aldU8ka/zfIPe0HvU7uQ==",
+			"version": "12.4.4",
+			"resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.4.tgz",
+			"integrity": "sha512-kTCb0DmEEIpUPS9l+/lZ1nMBF1BWtLoVgbiYyQCzK31ed45YNE8YqS0d6JO84J6KhLzN73r+edJd/tp7ZPQtDA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@formatjs/intl-durationformat": "^0.7.0",
@@ -1559,9 +1561,9 @@
 			}
 		},
 		"node_modules/@grafana/plugin-ui/node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -1571,23 +1573,36 @@
 				"uuid": "dist/esm/bin/uuid"
 			}
 		},
+		"node_modules/@grafana/react-data-grid": {
+			"version": "7.0.0-beta.57",
+			"resolved": "https://registry.npmjs.org/@grafana/react-data-grid/-/react-data-grid-7.0.0-beta.57.tgz",
+			"integrity": "sha512-v3DuW+TF16Jq5/dNJc0ifReBuknZb4+deB7M+liLMUU8sr2RavguNHpxCk4L/AdqLeXJFGhhqEDUYpeeQm2DzA==",
+			"license": "MIT",
+			"dependencies": {
+				"clsx": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": "^18.0 || ^19.0",
+				"react-dom": "^18.0 || ^19.0"
+			}
+		},
 		"node_modules/@grafana/runtime": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-12.3.3.tgz",
-			"integrity": "sha512-XfLeNoGf6HoZAHlqirCFoW8iLk4FNJxxKMeJSl6iqUFlu0bqN3B3JHiaaBmafJZ+bVV6ZeRcBP+d7qneQuh2Fw==",
+			"version": "12.4.4",
+			"resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-12.4.4.tgz",
+			"integrity": "sha512-RQk1TT6UdPAohTAsaeTXPX6H9eda1555/8lfr8eZATIEtKMRyEizmqSRSX9DzAtB4lJMzEDb5TFtqTcKmAjZJg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grafana/data": "12.3.3",
-				"@grafana/e2e-selectors": "12.3.3",
-				"@grafana/faro-web-sdk": "^1.13.2",
-				"@grafana/schema": "12.3.3",
-				"@grafana/ui": "12.3.3",
+				"@grafana/data": "12.4.4",
+				"@grafana/e2e-selectors": "12.4.4",
+				"@grafana/faro-web-sdk": "^2.2.4",
+				"@grafana/schema": "12.4.4",
+				"@grafana/ui": "12.4.4",
 				"@openfeature/core": "^1.9.0",
 				"@openfeature/ofrep-web-provider": "^0.3.3",
-				"@openfeature/web-sdk": "^1.6.1",
+				"@openfeature/react-sdk": "^1.2.0",
 				"@types/systemjs": "6.15.3",
 				"history": "4.10.1",
-				"lodash": "^4.17.23",
+				"lodash": "^4.18.1",
 				"react-loading-skeleton": "3.5.0",
 				"react-use": "17.6.0",
 				"rxjs": "7.8.2",
@@ -1599,9 +1614,9 @@
 			}
 		},
 		"node_modules/@grafana/schema": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.3.3.tgz",
-			"integrity": "sha512-0GkuXLENQfLDUFWQDyFxCtZPzMGC93STyez+0babBtolQq4SvOdAn0qkJW2PYjaGAaZqxKEzsrms6i3IE4jxqA==",
+			"version": "12.4.4",
+			"resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.4.4.tgz",
+			"integrity": "sha512-VHnIrGozUI3m8sxxF7fObFCTF+6zEdKy8XcWQABc7q7NESne92JthcS7lxkNlHTHzusq5Hzpl2Vgapj3S5CulA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "2.8.1"
@@ -1615,23 +1630,29 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@grafana/ui": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.3.3.tgz",
-			"integrity": "sha512-xmmT7XBUS92LqnBjPmO90uC4sqB5bPjk9S3XdEhLWyL8pD7Xi1wSrPBC0Tyrh4PI/J0tmz1+8q66pKllX4K91Q==",
+			"version": "12.4.4",
+			"resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.4.4.tgz",
+			"integrity": "sha512-xIEErYsCzkAftr4iWTzvVQPAjgMshG3oO/jEKjOn+nDkU6OuOA+q81ANifVeAHBYdd4Gj8HhwAQtxkMLudAffQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@emotion/css": "11.13.5",
 				"@emotion/react": "11.14.0",
 				"@emotion/serialize": "1.3.3",
 				"@floating-ui/react": "0.27.16",
-				"@grafana/data": "12.3.3",
-				"@grafana/e2e-selectors": "12.3.3",
-				"@grafana/faro-web-sdk": "^1.13.2",
-				"@grafana/i18n": "12.3.3",
-				"@grafana/schema": "12.3.3",
+				"@grafana/data": "12.4.4",
+				"@grafana/e2e-selectors": "12.4.4",
+				"@grafana/faro-web-sdk": "^2.2.4",
+				"@grafana/i18n": "12.4.4",
+				"@grafana/react-data-grid": "7.0.0-beta.57",
+				"@grafana/schema": "12.4.4",
 				"@hello-pangea/dnd": "18.0.1",
 				"@monaco-editor/react": "4.7.0",
 				"@popperjs/core": "2.11.8",
+				"@rc-component/cascader": "1.9.0",
+				"@rc-component/drawer": "1.3.0",
+				"@rc-component/picker": "1.7.1",
+				"@rc-component/slider": "1.0.1",
+				"@rc-component/tooltip": "1.4.0",
 				"@react-aria/dialog": "3.5.31",
 				"@react-aria/focus": "3.21.2",
 				"@react-aria/overlays": "3.30.0",
@@ -1652,21 +1673,15 @@
 				"immutable": "5.1.4",
 				"is-hotkey": "0.2.0",
 				"jquery": "3.7.1",
-				"lodash": "^4.17.23",
+				"lodash": "^4.18.1",
 				"micro-memoize": "^4.1.2",
 				"moment": "2.30.1",
 				"monaco-editor": "0.34.1",
-				"ol": "10.6.1",
+				"ol": "10.7.0",
 				"prismjs": "1.30.0",
-				"rc-cascader": "3.34.0",
-				"rc-drawer": "7.3.0",
-				"rc-picker": "4.11.3",
-				"rc-slider": "11.1.9",
-				"rc-tooltip": "6.4.0",
 				"react-calendar": "^6.0.0",
 				"react-colorful": "5.6.1",
 				"react-custom-scrollbars-2": "4.5.0",
-				"react-data-grid": "github:grafana/react-data-grid#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
 				"react-dropzone": "14.3.8",
 				"react-highlight-words": "0.21.0",
 				"react-hook-form": "^7.49.2",
@@ -2626,9 +2641,9 @@
 			}
 		},
 		"node_modules/@openfeature/core": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
-			"integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+			"integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@openfeature/ofrep-core": {
@@ -2652,28 +2667,39 @@
 				"@openfeature/web-sdk": "^1.4.0"
 			}
 		},
-		"node_modules/@openfeature/web-sdk": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.7.1.tgz",
-			"integrity": "sha512-cdN9J+ML8bthNCsdfCfPTQRrEVwoywaUzSuJRLbUeYidO3PmNnxtp0ccXJ2wikqq6vWqJvKhyyAyw2zKk7N/Ww==",
+		"node_modules/@openfeature/react-sdk": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@openfeature/react-sdk/-/react-sdk-1.4.0.tgz",
+			"integrity": "sha512-dRDvhkEVg/GqRToO2mO1JN2vm+pu86CWVnXM8SnB1yRujVkW21Leb6PcfyS6YjsF9Ob9JkqQtCrnpISd3OF8RQ==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@openfeature/core": "^1.9.0"
+				"@openfeature/web-sdk": "^1.9.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@openfeature/web-sdk": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.9.0.tgz",
+			"integrity": "sha512-FCrNfqvE/thHVfCNU0KKx1SD7rk+1wE2UaR5B5OPZl917QJv6AsKRwaI3N+SVgwXWI07GgtXP6hNlTVb49PGhg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"peerDependencies": {
+				"@openfeature/core": "^1.11.0"
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/api-logs": {
-			"version": "0.202.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
-			"integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+			"integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
@@ -2683,9 +2709,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-			"integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+			"integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2698,18 +2724,17 @@
 			}
 		},
 		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.202.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
-			"integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+			"integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.202.0",
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1",
-				"@opentelemetry/sdk-logs": "0.202.0",
-				"@opentelemetry/sdk-metrics": "2.0.1",
-				"@opentelemetry/sdk-trace-base": "2.0.1",
-				"protobufjs": "^7.3.0"
+				"@opentelemetry/api-logs": "0.218.0",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/sdk-logs": "0.218.0",
+				"@opentelemetry/sdk-metrics": "2.7.1",
+				"@opentelemetry/sdk-trace-base": "2.7.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2719,12 +2744,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
-			"integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+			"integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/core": "2.7.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -2735,14 +2760,15 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.202.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
-			"integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
+			"version": "0.218.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+			"integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.202.0",
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1"
+				"@opentelemetry/api-logs": "0.218.0",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2752,13 +2778,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
-			"integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+			"integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1"
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2768,13 +2794,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-			"integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+			"integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/resources": "2.7.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -2785,9 +2811,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
-			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -3159,79 +3185,164 @@
 				"url": "https://opencollective.com/popperjs"
 			}
 		},
-		"node_modules/@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"node_modules/@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@rc-component/portal": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
-			"integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+		"node_modules/@rc-component/cascader": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.9.0.tgz",
+			"integrity": "sha512-2jbthe1QZrMBgtCvNKkJFjZYC3uKl4N/aYm5SsMvO3T+F+qRT1CGsSM9bXnh1rLj7jDk/GK0natShWF/jinhWQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.18.0",
-				"classnames": "^2.3.2",
-				"rc-util": "^5.24.4"
+				"@rc-component/select": "~1.3.0",
+				"@rc-component/tree": "~1.1.0",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/drawer": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.3.0.tgz",
+			"integrity": "sha512-rE+sdXEmv2W25VBQ9daGbnb4J4hBIEKmdbj0b3xpY+K7TUmLXDIlSnoXraIbFZdGyek9WxxGKK887uRnFgI+pQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/portal": "^2.0.0",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/motion": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.3.tgz",
+			"integrity": "sha512-Xh3IszxvlSv3/PLYFyC2UZi9LNB83yOnkB/LNmRzaypZLvkhqUIPS7MQpGZcCMWrNsXV2p6YTSWbSGvFpEle9A==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/util": "^1.11.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/overflow": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.1.tgz",
+			"integrity": "sha512-syfmgAABaHCnCDzPwHZ/2tuvIcpOO3jefYZMmfkN+pmo8HKTzsfhS57vxo4ksPdN0By+uWVJhJWNFozNBxi2eA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"@rc-component/resize-observer": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/picker": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.7.1.tgz",
+			"integrity": "sha512-u75rwgbYbH3M2+k22dWOCXv1YUtdb5bgrD7YXCV19H6qS6mUHxQOcqRVTU2JmUPKkq+TOaHC4kDgU83mN2G01w==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/trigger": "^3.6.15",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1",
+				"rc-overflow": "^1.3.2"
+			},
+			"engines": {
+				"node": ">=12.x"
+			},
+			"peerDependencies": {
+				"date-fns": ">= 2.x",
+				"dayjs": ">= 1.x",
+				"luxon": ">= 3.x",
+				"moment": ">= 2.x",
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			},
+			"peerDependenciesMeta": {
+				"date-fns": {
+					"optional": true
+				},
+				"dayjs": {
+					"optional": true
+				},
+				"luxon": {
+					"optional": true
+				},
+				"moment": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rc-component/portal": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.1.tgz",
+			"integrity": "sha512-ck+r1kW/JSv0wxPji3KN2ss9K6Z0qqwusw/mf/0JobXhZ8hC2ejZwCJObW/SvDi0uhA0VzmCnx0CaCci95tcmA==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/util": "^1.11.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/resize-observer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
+			"integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/util": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/select": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.3.6.tgz",
+			"integrity": "sha512-CzbJ9TwmWcF5asvTMZ9BMiTE9CkkrigeOGRPpzCNmeZP7KBwwmYrmOIiKh9tMG7d6DyGAEAQ75LBxzPx+pGTHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/overflow": "^1.0.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/@rc-component/slider": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
+			"integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=8.x"
@@ -3239,27 +3350,93 @@
 			"peerDependencies": {
 				"react": ">=16.9.0",
 				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/tooltip": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+			"integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/trigger": "^3.7.1",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.1.0.tgz",
+			"integrity": "sha512-HZs3aOlvFgQdgrmURRc/f4IujiNBf4DdEeXUlkS0lPoLlx9RoqsZcF0caXIAMVb+NaWqKtGQDnrH8hqLCN5zlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@rc-component/motion": "^1.0.0",
+				"@rc-component/util": "^1.2.1",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=10.x"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
 			}
 		},
 		"node_modules/@rc-component/trigger": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.0.tgz",
-			"integrity": "sha512-iwaxZyzOuK0D7lS+0AQEtW52zUWxoGqTGkke3dRyb8pYiShmRpCjB/8TzPI4R6YySCH7Vm9BZj/31VPiiQTLBg==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.1.tgz",
+			"integrity": "sha512-LNsYvz60mrLJ/kRvKcHE7boUvcQfVMCfRqZ71x3Fo9AOiZ1KKIEqkzMA8DNvz2V3Bcvir/vwQNn7JF1NPODQ7Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.23.2",
-				"@rc-component/portal": "^1.1.0",
-				"classnames": "^2.3.2",
-				"rc-motion": "^2.0.0",
-				"rc-resize-observer": "^1.3.1",
-				"rc-util": "^5.44.0"
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/portal": "^2.2.0",
+				"@rc-component/resize-observer": "^1.1.1",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=8.x"
 			},
 			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/util": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.11.1.tgz",
+			"integrity": "sha512-awVlI3ub2vqfqkYxOBc/uQ0efm3jw0wcrhtO/YWLyZfxiKXczKwNbVuhlnyxytDt7H9pbbVQiqr+O6MLATtRYg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-mobile": "^5.0.0",
+				"react-is": "^18.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/virtual-list": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.2.0.tgz",
+			"integrity": "sha512-iavRm1Jo4GDbASQwdGa7jFyk93RvSOo9xHyBT4QL1pgFJj/Fdf1G+3RErH7/7BmAMvx2AkF62mjGYxDbXsK9TQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.20.0",
+				"@rc-component/resize-observer": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
 			}
 		},
 		"node_modules/@react-aria/dialog": {
@@ -3446,12 +3623,6 @@
 				"@babel/runtime": "^7.23.2"
 			}
 		},
-		"node_modules/@react-awesome-query-builder/core/node_modules/immutable": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-			"integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-			"license": "MIT"
-		},
 		"node_modules/@react-awesome-query-builder/ui": {
 			"version": "6.6.15",
 			"resolved": "https://registry.npmjs.org/@react-awesome-query-builder/ui/-/ui-6.6.15.tgz",
@@ -3607,9 +3778,9 @@
 			}
 		},
 		"node_modules/@remix-run/router": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-			"integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+			"version": "1.23.3",
+			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+			"integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -4299,6 +4470,7 @@
 			"version": "24.10.9",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
 			"integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -5719,9 +5891,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -6179,9 +6351,9 @@
 			}
 		},
 		"node_modules/cosmiconfig/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
 			"license": "ISC",
 			"engines": {
 				"node": ">= 6"
@@ -6943,9 +7115,9 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -7546,9 +7718,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7652,9 +7824,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -7862,9 +8034,9 @@
 			"integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8000,9 +8172,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"license": "ISC"
 		},
 		"node_modules/for-each": {
@@ -8080,9 +8252,9 @@
 			}
 		},
 		"node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8847,9 +9019,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-			"integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+			"integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
 			"license": "MIT"
 		},
 		"node_modules/import-fresh": {
@@ -9252,6 +9424,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/is-mobile": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+			"integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.3",
@@ -10566,9 +10744,9 @@
 			}
 		},
 		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10775,9 +10953,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-cookie": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+			"integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
 			"license": "MIT"
 		},
 		"node_modules/js-tokens": {
@@ -11030,9 +11208,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -11040,12 +11218,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"license": "MIT"
-		},
-		"node_modules/long": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"license": "Apache-2.0"
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
@@ -11138,12 +11310,12 @@
 			}
 		},
 		"node_modules/marked-mangle": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.11.tgz",
-			"integrity": "sha512-BUZiRqPooKZZhC7e8aDlzqkZt4MKkbJ/VY22b8iqrI3fJdnWmSyc7/uujDkrMszZrKURrXsYVUfgdWG6gEspcA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.12.tgz",
+			"integrity": "sha512-bRrqNcfU9v3iRECb7YPvA+/xKZMjHojd9R92YwHbFjdPQ+Wc7vozkbGKAv4U8AUl798mNUuY3DTBQkedsV3TeQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"marked": ">=4 <17"
+				"marked": ">=4 <18"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -11398,9 +11570,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -11619,9 +11791,9 @@
 			}
 		},
 		"node_modules/ol": {
-			"version": "10.6.1",
-			"resolved": "https://registry.npmjs.org/ol/-/ol-10.6.1.tgz",
-			"integrity": "sha512-xp174YOwPeLj7c7/8TCIEHQ4d41tgTDDhdv6SqNdySsql5/MaFJEJkjlsYcvOPt7xA6vrum/QG4UdJ0iCGT1cg==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
+			"integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@types/rbush": "4.0.0",
@@ -11934,9 +12106,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12097,9 +12269,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -12117,7 +12289,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -12304,34 +12476,10 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"license": "MIT"
 		},
-		"node_modules/protobufjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
 		"node_modules/protocol-buffers-schema": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-			"integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+			"integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
 			"license": "MIT"
 		},
 		"node_modules/punycode": {
@@ -12361,9 +12509,9 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -12409,16 +12557,6 @@
 			"integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
 			"license": "MIT"
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/raw-body": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
@@ -12443,55 +12581,6 @@
 				"quickselect": "^3.0.0"
 			}
 		},
-		"node_modules/rc-cascader": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.34.0.tgz",
-			"integrity": "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.25.7",
-				"classnames": "^2.3.1",
-				"rc-select": "~14.16.2",
-				"rc-tree": "~5.13.0",
-				"rc-util": "^5.43.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-drawer": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.3.0.tgz",
-			"integrity": "sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.23.9",
-				"@rc-component/portal": "^1.1.1",
-				"classnames": "^2.2.6",
-				"rc-motion": "^2.6.1",
-				"rc-util": "^5.38.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-motion": {
-			"version": "2.9.5",
-			"resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
-			"integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.11.1",
-				"classnames": "^2.2.1",
-				"rc-util": "^5.44.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
 		"node_modules/rc-overflow": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
@@ -12506,45 +12595,6 @@
 			"peerDependencies": {
 				"react": ">=16.9.0",
 				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-picker": {
-			"version": "4.11.3",
-			"resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.3.tgz",
-			"integrity": "sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.24.7",
-				"@rc-component/trigger": "^2.0.0",
-				"classnames": "^2.2.1",
-				"rc-overflow": "^1.3.2",
-				"rc-resize-observer": "^1.4.0",
-				"rc-util": "^5.43.0"
-			},
-			"engines": {
-				"node": ">=8.x"
-			},
-			"peerDependencies": {
-				"date-fns": ">= 2.x",
-				"dayjs": ">= 1.x",
-				"luxon": ">= 3.x",
-				"moment": ">= 2.x",
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			},
-			"peerDependenciesMeta": {
-				"date-fns": {
-					"optional": true
-				},
-				"dayjs": {
-					"optional": true
-				},
-				"luxon": {
-					"optional": true
-				},
-				"moment": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/rc-resize-observer": {
@@ -12563,82 +12613,6 @@
 				"react-dom": ">=16.9.0"
 			}
 		},
-		"node_modules/rc-select": {
-			"version": "14.16.8",
-			"resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.8.tgz",
-			"integrity": "sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.10.1",
-				"@rc-component/trigger": "^2.1.1",
-				"classnames": "2.x",
-				"rc-motion": "^2.0.1",
-				"rc-overflow": "^1.3.1",
-				"rc-util": "^5.16.1",
-				"rc-virtual-list": "^3.5.2"
-			},
-			"engines": {
-				"node": ">=8.x"
-			},
-			"peerDependencies": {
-				"react": "*",
-				"react-dom": "*"
-			}
-		},
-		"node_modules/rc-slider": {
-			"version": "11.1.9",
-			"resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.9.tgz",
-			"integrity": "sha512-h8IknhzSh3FEM9u8ivkskh+Ef4Yo4JRIY2nj7MrH6GQmrwV6mcpJf5/4KgH5JaVI1H3E52yCdpOlVyGZIeph5A==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.10.1",
-				"classnames": "^2.2.5",
-				"rc-util": "^5.36.0"
-			},
-			"engines": {
-				"node": ">=8.x"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-tooltip": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
-			"integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.11.2",
-				"@rc-component/trigger": "^2.0.0",
-				"classnames": "^2.3.1",
-				"rc-util": "^5.44.3"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-tree": {
-			"version": "5.13.1",
-			"resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.1.tgz",
-			"integrity": "sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.10.1",
-				"classnames": "2.x",
-				"rc-motion": "^2.0.1",
-				"rc-util": "^5.16.1",
-				"rc-virtual-list": "^3.5.1"
-			},
-			"engines": {
-				"node": ">=10.x"
-			},
-			"peerDependencies": {
-				"react": "*",
-				"react-dom": "*"
-			}
-		},
 		"node_modules/rc-util": {
 			"version": "5.44.4",
 			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
@@ -12647,25 +12621,6 @@
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"react-is": "^18.2.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0",
-				"react-dom": ">=16.9.0"
-			}
-		},
-		"node_modules/rc-virtual-list": {
-			"version": "3.19.2",
-			"resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.19.2.tgz",
-			"integrity": "sha512-Ys6NcjwGkuwkeaWBDqfI3xWuZ7rDiQXlH1o2zLfFzATfEgXcqpk8CkgMfbJD81McqjcJVez25a3kPxCR807evA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.20.0",
-				"classnames": "^2.2.6",
-				"rc-resize-observer": "^1.0.0",
-				"rc-util": "^5.36.0"
-			},
-			"engines": {
-				"node": ">=8.x"
 			},
 			"peerDependencies": {
 				"react": ">=16.9.0",
@@ -12732,19 +12687,6 @@
 			"peerDependencies": {
 				"react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
 				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
-		"node_modules/react-data-grid": {
-			"version": "7.0.0-beta.56",
-			"resolved": "git+ssh://git@github.com/grafana/react-data-grid.git#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
-			"integrity": "sha512-kE4U/hBd5rNeKT2poz+uMfVlaSqjVLVXs0ZAP674DImFnri/6ARhEtr+6szEboNepQgWXEJYIWtdZ7GbaBpexw==",
-			"license": "MIT",
-			"dependencies": {
-				"clsx": "^2.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0 || ^19.0",
-				"react-dom": "^18.0 || ^19.0"
 			}
 		},
 		"node_modules/react-dom": {
@@ -12978,14 +12920,14 @@
 			}
 		},
 		"node_modules/react-router-dom-v5-compat": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.0.tgz",
-			"integrity": "sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==",
+			"version": "6.30.4",
+			"resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.4.tgz",
+			"integrity": "sha512-lJP6Zl6DYQtmrnaOV7MW5s/Npe7mYOokwekaPAqjCgIMQmZFfdA8mfoe5kWJoT/xedSdgZLrfFVHx18RUIIcEw==",
 			"license": "MIT",
 			"dependencies": {
-				"@remix-run/router": "1.23.0",
+				"@remix-run/router": "1.23.3",
 				"history": "^5.3.0",
-				"react-router": "6.30.0"
+				"react-router": "6.30.4"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -13006,12 +12948,12 @@
 			}
 		},
 		"node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-			"integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+			"version": "6.30.4",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+			"integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
 			"license": "MIT",
 			"dependencies": {
-				"@remix-run/router": "1.23.0"
+				"@remix-run/router": "1.23.3"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -13665,13 +13607,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -14561,16 +14503,15 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.16",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-			"integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -14584,10 +14525,37 @@
 				"webpack": "^5.1.0"
 			},
 			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
 				"@swc/core": {
 					"optional": true
 				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
 				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
 					"optional": true
 				},
 				"uglify-js": {
@@ -14670,9 +14638,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14801,9 +14769,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -15206,6 +15174,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {
@@ -15339,9 +15308,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+			"integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
@@ -15442,9 +15411,9 @@
 			}
 		},
 		"node_modules/web-vitals": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-			"integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/web-worker": {
@@ -15923,9 +15892,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -16007,9 +15976,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -16017,6 +15986,9 @@
 			},
 			"engines": {
 				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {
@@ -16071,12 +16043,10 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-			"integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
-			"dev": true,
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -79,5 +79,10 @@
 		"react-dom": "18.3.1",
 		"tslib": "2.8.1"
 	},
-	"packageManager": "npm@11.7.0"
+	"packageManager": "npm@11.7.0",
+	"overrides": {
+		"serialize-javascript": "^7.0.5",
+		"js-cookie": "^3.0.8",
+		"immutable": "^5.1.6"
+	}
 }


### PR DESCRIPTION
Second validator failure on the `v0.1.6` release ([run 27442618771](https://github.com/HarperFast/grafana-datasource/actions/runs/27442618771)): the Go CVEs from #174 are cleared, but osv-scanner now flags npm packages, all high severity:

- `fast-uri` 3.1.0 — CVE-2026-6321, CVE-2026-6322
- `flatted` 3.3.3 — CVE-2026-32141, CVE-2026-33228
- `serialize-javascript` 6.0.2 — RCE (GHSA-5c6j-r48x-rmvq), DoS (GHSA-qj8w-gfj5-8c6v)

## Changes

- `npm audit fix` (non-breaking): resolves `fast-uri` → 3.1.2 and `flatted` → 3.4.2 in the lockfile
- `overrides` in package.json:
  - `serialize-javascript` ^7.0.5 — its parent `copy-webpack-plugin@13` pins ^6 and the fix is only in 7.x; cwp@14 would be a breaking upgrade
  - `js-cookie` ^3.0.8 and `immutable` ^5.1.6 — also rated high by npm audit; fixing preemptively so the next release doesn't trip on them

Remaining: 5 moderate findings inside `@grafana/ui`'s own deps (dompurify, uuid) — below the validator's gate and not fixable downstream.

## Verification

- `npm run build`, `typecheck`, `test:ci` all pass with the overrides (the webpack build exercises copy-webpack-plugin against serialize-javascript 7)
- `npm audit`: 0 high/critical remaining

After merge: move the `v0.1.6` tag to the merge commit and re-push to retry the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)